### PR TITLE
requirements: Add pyyaml requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click>=6.0,<8.0
 jira>=3.8
 requests>2.0,<3.0
 tabulate>=0.8
+pyyaml


### PR DESCRIPTION
I ran `pip install -e .` in a virtualenv, and jcli threw an exception when it attempted to import `yaml`. This fixed the issue for me.