### PR TITLE
issues: add initial support for using csv input to update issues

### DIFF
--- a/jcli/shell.py
+++ b/jcli/shell.py
@@ -61,6 +61,7 @@ issues.add_command(issues_cmds.add_comment_cmd)
 issues.add_command(issues_cmds.states_cmd)
 issues.add_command(issues_cmds.set_state_cmd)
 issues.add_command(issues_cmds.set_field_cmd)
+issues.add_command(issues_cmds.set_field_from_csv_cmd)
 
 details.add_command(details_cmds.last_states_cmd)
 


### PR DESCRIPTION
Adding the ability to use a csv file as a means to bulk update issues. This can be handy for setting things like Story Points, or Priority.

The input csv should arrive with no header, though if that becomes needed for some reason we can factor it in. Tested with Story Points and Priority fields:

test.csv contents:
```
ABC-14,Story Points,13
ABC-14,priority,Normal
```

```
$ jcli issues set-field-from-csv ~/test.csv
Updated ABC-14, set Story Points: 8.0 -> 13.0
Updated ABC-14, set priority: Normal -> Normal
```
