### PR TITLE
markdown: support multiline quotes.

### DIFF
--- a/jcli/utils.py
+++ b/jcli/utils.py
@@ -227,7 +227,7 @@ def md_to_jira(text):
     # modifying them
 
     # Convert Markdown blockquotes (`> `) to Jira `{noformat}`
-    blockquote_pattern = re.compile(r'(^> .+(?:\n> .+)*)', re.MULTILINE)
+    blockquote_pattern = re.compile(r'(^> .+(?:\n>(?:(?: .*)|$))*)', re.MULTILINE)
     text = blockquote_pattern.sub(
         lambda m: "{noformat}\n" + "\n".join(line.lstrip("> ") for line in m.group(1).splitlines()) + "\n{noformat}",
         text


### PR DESCRIPTION
Markdown quotes can be empty lines, i.e:

>·One·line
>
>·Another

(Artificially replaced " " with "·")

However, when automatically generating quotes (as in --reply-to), the easy (and clean) way is to append "> " to every line, just as email clients do, resulting in:

>·One·line
>·
>·Another

(Artificially replaced " " with "·")

Both blocks should be translated into:

{noformat}
One·line

Another
{noformat}

This patch attemps to support that.
Also, test strings are made multi-line strings to reduce eye-strain.