### PR TITLE
issues create: allow using a jobj from the context

### DIFF
--- a/jcli/connector.py
+++ b/jcli/connector.py
@@ -917,7 +917,9 @@ class JiraConnector(object):
         if self.jira is None:
             raise RuntimeError("Need to log-in first.")
 
-        return self.jira.create_issue(issue_dict)
+        result = self.jira.create_issue(issue_dict)
+        self.last_issue = result
+        return result
 
     def _find_users_by_key(self, key):
         user = User(self.jira._options, self.jira._session, _query_param='key')

--- a/jcli/issues.py
+++ b/jcli/issues.py
@@ -770,7 +770,7 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
 
     if project != "Default Project" and show_fields:
         # Try to pull the default fields for project and bug type
-        special_lines += "# Assignable fields below:\n"
+        special_lines += "\n# Assignable fields below:\n"
 
         for f in jobj.get_project_default_types(project, issue_type):
             f = '"' + f + '"'

--- a/jcli/issues.py
+++ b/jcli/issues.py
@@ -682,6 +682,7 @@ def issue_extract_blocks(issue_block):
 @click.command(
     name='create'
 )
+@click.pass_context
 @click.option("--summary", type=str, default=None,
               help="The summary for the issue.  Default is to use the text editor interpretation.")
 @click.option("--description", type=str, default=None,
@@ -708,10 +709,14 @@ def issue_extract_blocks(issue_block):
               " issue type.  Must specify valid values for both on the command line.")
 @click.option("--dry-run", is_flag=True, default=False,
               help="Do not actually commit the issue.")
-def create_issue_cmd(summary, description, project, issue_type, set_field,
+def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
                      from_file, commit, oneline, verbose, show_fields, dry_run):
-    jobj = connector.JiraConnector()
-    jobj.login()
+    if 'jobj' not in ctx.obj:
+        jobj = connector.JiraConnector()
+        jobj.login()
+        ctx.obj['jobj'] = jobj
+    else:
+        jobj = ctx.obj['jobj']
 
     filled_all = all((summary, description, project))
     special_lines = None


### PR DESCRIPTION
This allows using a jobj instantiated somewhere else (like in some other
app) and have the same jira context. The use case at hand already is to
return the created jira id.