### PR TITLE
markdown: Improved support.

### DIFF
--- a/jcli/test/test_issues.py
+++ b/jcli/test/test_issues.py
@@ -81,7 +81,8 @@ Looking at the code, we see::
 if (hokey)
     self.turn_about()
 {code}
-However, the hokey flag never seems to have gotten cleared.
+However, the hokey flag never seems to have gotten cleared.  We can see from the turn_about() function that _sometimes_ it works but detect_that_we_turned_around() doesn't always work.
+*important* we can verify this with a good test.
 I pulled the details from [here|https://www.example.com/hokey-pokey-spec/2025/01/01/spec.txt] and the pdf [here|ftp://www.example.com/hokey-pokey-spec/2025/01/01/spec.pdf]
 """
 
@@ -101,7 +102,8 @@ if (hokey)
     self.turn_about()
 
 ```
-However, the hokey flag never seems to have gotten cleared.
+However, the hokey flag never seems to have gotten cleared.  We can see from the turn_about() function that *sometimes* it works but detect_that_we_turned_around() doesn't always work.
+**important** we can verify this with a good test.
 I pulled the details from [here](https://www.example.com/hokey-pokey-spec/2025/01/01/spec.txt) and the pdf [here](ftp://www.example.com/hokey-pokey-spec/2025/01/01/spec.pdf)
 """
 

--- a/jcli/utils.py
+++ b/jcli/utils.py
@@ -240,8 +240,8 @@ def jira_to_md(text):
     text, all_blocks = extract_protected_blocks(text, 'code(:[a-zA-Z0-9]+)?', all_blocks)
 
     # Convert lists (need to do this before headers)
-    text = re.sub(r'^\*\s*(.*?)$', r'- \1', text, flags=re.MULTILINE)
-    text = re.sub(r'^#\s*(.*?)$', r'1. \1', text, flags=re.MULTILINE)
+    text = re.sub(r'^\*\s+(.*?)$', r'- \1', text, flags=re.MULTILINE)
+    text = re.sub(r'^#\s+(.*?)$', r'1. \1', text, flags=re.MULTILINE)
 
     # Convert headers
     text = re.sub(r'^h1\.\s*(.*?)$', r'# \1', text, flags=re.MULTILINE)
@@ -249,8 +249,8 @@ def jira_to_md(text):
     text = re.sub(r'^h3\.\s*(.*?)$', r'### \1', text, flags=re.MULTILINE)
 
     # Convert bold and italics
-    text = re.sub(r'\*(.*?)\*', r'**\1**', text)
-    text = re.sub(r'_(.*?)_', r'*\1*', text)
+    text = re.sub(r'([^a-zA-Z0-9()+-\.=\[\]]+)\*([a-zA-Z0-9\.+-]+)\*', r'\1**\2**', text)
+    text = re.sub(r'([^a-zA-Z0-9()+-\.=\[\]]+)_([a-zA-Z0-9\.+-]+)_', r'\1*\2*', text)
 
     # Convert inline code
     text = re.sub(r'{{(.*?)}}', r'`\1`', text)
@@ -311,8 +311,8 @@ def md_to_jira(text):
     text = re.sub(r'^###\s*(.*?)$', r'h3. \1', text, flags=re.MULTILINE)
 
     # Convert bold and italics
-    text = re.sub(r'\*\*(.*?)\*\*', r'*\1*', text)
-    text = re.sub(r'\*(.*?)\*', r'_\1_', text)
+    text = re.sub(r'([^a-zA-Z0-9()+-\.=\[\]\*]+)\*([^*]+)\*', r'\1_\2_', text)
+    text = re.sub(r'([^a-zA-Z0-9()+-\.=\[\]]+)\*\*(.+)\*\*', r'\1*\2*', text)
 
     # Convert inline code and code blocks
     text = re.sub(r'`(.*?)`', r'{{\1}}', text)


### PR DESCRIPTION
Markdown conversion was missing some useful exclusions on specific sets of characters when converting the bold/italics encoding.  This patch improves thigns with a more restrictive set of character classes to use when converting.

Fixes: https://github.com/apconole/jiracli/issues/15