### PR TITLE
Fix set summary field

### DIFF
--- a/jcli/connector.py
+++ b/jcli/connector.py
@@ -782,6 +782,9 @@ class JiraConnector(object):
         if isinstance(var_instance, list):
             return [{"name": value}]
 
+        if isinstance(var_instance, str):
+            return str(value)
+
         try:
             if 'name' in var_instance:
                 return {"name": value}


### PR DESCRIPTION
When trying to set the summary field I got an error:
```
        response text = {"errorMessages":[],"errors":{"summary":"Operation value must be a string"}}
```

after a bit of debugging i figured out that the problem is in the `convert_to_jira_type` method not supporting the string type.

With this fix, updating the summary field now works.