### PR TITLE
utils: skip paging if stdout is not a tty

### DIFF
--- a/jcli/utils.py
+++ b/jcli/utils.py
@@ -139,6 +139,10 @@ def _display_via_pager(pager, output):
 
 
 def display_via_pager(output, title=None):
+    if not sys.stdout.isatty():
+        sys.stdout.write(output)
+        return
+
     if title:
         click.echo(f"\033]0;{title}\007", nl=False)  # Set terminal title
 


### PR DESCRIPTION
If the user is redirecting the output of jcli to a file or piping it to something else, skip paging.