### PR TITLE
jcli.issues: add --json for issue create command

### DIFF
--- a/jcli/issues.py
+++ b/jcli/issues.py
@@ -914,6 +914,10 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
     fields = {}
     set_field = set_field or []
 
+    if verbose and json:
+        click.echo("INVALID - cannot set both verbose and json flags.")
+        sys.exit(1)
+
     if commit:
         if len(commit) == 1 and not oneline:
             # treat this as a from-file with a specific commit.
@@ -924,8 +928,16 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
             for sha in commit:
                 commit_line = git_get_commit_oneline(sha)
                 if not commit_line or not len(commit_line):
-                    click.echo(f"ERROR: Unable to find {sha}")
-                    click.echo("Please make sure you are in a git tree, or GIT_DIR is defined.")
+                    if not json:
+                        click.echo(f"ERROR: Unable to find {sha}")
+                        click.echo(
+                            "Please make sure you are in a git tree, or "
+                            "GIT_DIR is defined.")
+                    else:
+                        click.echo(JSON.dumps({"success": False,
+                                               "issue_id": None,
+                                               "error":
+                                               f"Unable to find sha {sha}"}))
                     sys.exit(1)
                 commit_lines = commit_line.split("\n")
                 for commit_line in commit_lines:
@@ -984,7 +996,15 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
 
         if issue_patch == template_data and not (from_file or
                                                  (commit and not oneline)):
-            click.echo("Issue text not set.  Please fill in project, summary, and description.")
+            if not json:
+                click.echo("Issue text not set.  Please fill in project, "
+                           "summary, and description.")
+            else:
+                click.echo(JSON.dumps({"success": False,
+                                       "issue_id": None,
+                                       "error":
+                                       "Issue text not set.  Please fill in "
+                                       "project, summary, and description."}))
             sys.exit(1)
     else:
         issue_patch = template_data
@@ -1011,11 +1031,22 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
     issue["issuetype"] = issue_type
     if dry_run or verbose:
         click.echo(f"Creating: {pprint.pformat(issue)}")
-    result = "DRY-OKAY" if dry_run else jobj.create_issue(issue)
-    if json and not dry_run:
-        click.echo(JSON.dumps(result.raw))
-    else:
-        click.echo(f"done - Result: {result}.")
+
+    try:
+        result = "DRY-OKAY" if dry_run else jobj.create_issue(issue)
+        if json:
+            click.echo(JSON.dumps({"success": True,
+                                   "issue_id": result if dry_run else result.key,
+                                   "raw": None if dry_run else result.raw}))
+        else:
+            click.echo(f"done - Result: {result}.")
+    except Exception as e:
+        if json:
+            click.echo(JSON.dumps({"success": False,
+                                   "issue_id": None,
+                                   "error": str(e)}))
+        else:
+            click.echo(f"Unable to create issue - {str(e)}.")
 
 
 @click.command(

--- a/jcli/issues.py
+++ b/jcli/issues.py
@@ -886,8 +886,11 @@ def issue_extract_blocks(issue_block):
               " issue type.  Must specify valid values for both on the command line.")
 @click.option("--dry-run", is_flag=True, default=False,
               help="Do not actually commit the issue.")
+@click.option("--json", is_flag=True, default=False,
+              help="Output the created issue in JSON format.")
 def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
-                     from_file, commit, oneline, verbose, show_fields, dry_run):
+                     from_file, commit, oneline, verbose, show_fields, dry_run,
+                     json):
     """Creates a new JIRA issue.
 
     Supports creating a JIRA issue from the command line, using a 'git' like
@@ -1009,7 +1012,10 @@ def create_issue_cmd(ctx, summary, description, project, issue_type, set_field,
     if dry_run or verbose:
         click.echo(f"Creating: {pprint.pformat(issue)}")
     result = "DRY-OKAY" if dry_run else jobj.create_issue(issue)
-    click.echo(f"done - Result: {result}.")
+    if json and not dry_run:
+        click.echo(JSON.dumps(result.raw))
+    else:
+        click.echo(f"done - Result: {result}.")
 
 
 @click.command(

--- a/jcli/test/stubs.py
+++ b/jcli/test/stubs.py
@@ -43,6 +43,9 @@ class JiraIssueStub(dict):
     def __init__(self):
         self['raw'] = {}
 
+    def __str__(self):
+        return self.get('key', '')
+
 
 class JiraCommentStub(dict):
     def __getattr__(self, attr):
@@ -254,7 +257,6 @@ class JiraConnectorStub(JiraConnector):
         return field_value
 
     def create_issue(self, issue_dict):
-        print("Including an issue.")
         if 'summary' not in issue_dict or \
            'description' not in issue_dict or \
            'issuetype' not in issue_dict or \
@@ -279,7 +281,7 @@ class JiraConnectorStub(JiraConnector):
         stub['summary'] = issue_dict['summary']
         stub['statusId'] = 0
         JiraConnectorStub._issues_list.append(stub)
-        return key
+        return stub
 
     def add_issue_link(self, issue, target, title=None, link_type=None, isinward=False):
         JiraConnectorStub._issue_links.append({

--- a/jcli/test/test_issues.py
+++ b/jcli/test/test_issues.py
@@ -242,6 +242,26 @@ DESC: {issue_description}
 
 
 @patch('jcli.connector.JiraConnector', JiraConnectorStub)
+def test_issue_create_json(cli_runner):
+    JiraConnectorStub.setup_clear_issues()
+
+    issue_summary = "JSON output test"
+    issue_description = "Testing JSON output for create."
+    issue_project = "ABC"
+
+    result = cli_runner.invoke(create_issue_cmd,
+                               ['--json',
+                                '--summary', issue_summary,
+                                '--description', issue_description,
+                                '--project', issue_project,
+                                '--issue-type', 'Bug'], obj={})
+    assert result.exit_code == 0
+    json_obj = json.loads(result.output)
+    assert 'fields' in json_obj
+    assert json_obj['fields']['summary'] == issue_summary
+
+
+@patch('jcli.connector.JiraConnector', JiraConnectorStub)
 def test_issue_case_cmp(cli_runner):
     JiraConnectorStub.setup_clear_issues()
 

--- a/jcli/test/test_issues.py
+++ b/jcli/test/test_issues.py
@@ -257,8 +257,10 @@ def test_issue_create_json(cli_runner):
                                 '--issue-type', 'Bug'], obj={})
     assert result.exit_code == 0
     json_obj = json.loads(result.output)
-    assert 'fields' in json_obj
-    assert json_obj['fields']['summary'] == issue_summary
+    assert json_obj['success'] is True
+    assert json_obj['issue_id'] == 'ISSUE-1'
+    assert 'fields' in json_obj['raw']
+    assert json_obj['raw']['fields']['summary'] == issue_summary
 
 
 @patch('jcli.connector.JiraConnector', JiraConnectorStub)


### PR DESCRIPTION
This outputs the issue creation result as a json instead of just a string. This should help with integrating with script tooling so that the result doesn't have to be parsed via regex.

Also adds a related test case.

Co-authored via Claude, using Opus4.6 model.

Resolves #29 